### PR TITLE
Make CSV Table Display Collapsible

### DIFF
--- a/src/autogluon_dashboard/app.py
+++ b/src/autogluon_dashboard/app.py
@@ -148,7 +148,6 @@ plot_ctr = iter(range(len(plots)))
 template = pn.template.FastListTemplate(
     title=APP_TITLE,
     main=[
-        pn.Row(ALL_FRAMEWORKS_IDF, per_framework_dfi),
         pn.Row(
             ALL_DATA_COMP,
             pn.WidgetBox(yaxis_widget, graph_dropdown),
@@ -163,6 +162,7 @@ template = pn.template.FastListTemplate(
         ),
         pn.Row(NO_RANK_COMP, ag_pct_rank1, plots[next(plot_ctr)]),
         pn.Row(NO_ERROR_CNTS, plots[next(plot_ctr)]),
+        pn.Card(per_framework_dfi, title=ALL_FRAMEWORKS_IDF[1:], collapsed=True),
     ],
     header_background=APP_HEADER_BACKGROUND,
 )


### PR DESCRIPTION
This PR addresses the need to give the user the option to collapse the CSV table for aggregated evaluation data per framework. Since this table display is not very crucial and is only intended for additional context, it has been moved to the bottom of the page. 
Below are screenshots depecting this change: 
![Screenshot 2023-06-29 at 4 44 13 PM](https://github.com/autogluon/autogluon-dashboard/assets/54525027/b6291b17-0c6c-43ef-9dad-9fc9e02c2646)

![Screenshot 2023-06-29 at 4 44 29 PM](https://github.com/autogluon/autogluon-dashboard/assets/54525027/560e7d01-b109-4235-9bf9-d41069f0c82d)
