### PR TITLE
Remove Union with default None and use Optional for type hint. Use empty list instead of Ellipsis for default table columns list

### DIFF
--- a/src/autogluon_dashboard/plotting/all_plots.py
+++ b/src/autogluon_dashboard/plotting/all_plots.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot.pandas
 
@@ -10,8 +10,8 @@ class Plot:
         plot_title: str,
         dataset_to_plot: hvplot.Interactive,
         plot_type: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",

--- a/src/autogluon_dashboard/plotting/framework_error.py
+++ b/src/autogluon_dashboard/plotting/framework_error.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot
 
@@ -11,13 +11,13 @@ class FrameworkError(Plot):
         plot_title: str,
         dataset_to_plot: hvplot.Interactive,
         plot_type: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
-        table_cols: list = ...,
+        table_cols: list = [],
     ) -> None:
         super().__init__(
             plot_title,

--- a/src/autogluon_dashboard/plotting/metrics_all_datasets.py
+++ b/src/autogluon_dashboard/plotting/metrics_all_datasets.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot
 
@@ -11,13 +11,13 @@ class MetricsPlotAll(Plot):
         plot_title: str,
         dataset_to_plot: hvplot.Interactive,
         plot_type: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
-        table_cols: list = ...,
+        table_cols: list = [],
     ) -> None:
         super().__init__(
             plot_title,

--- a/src/autogluon_dashboard/plotting/metrics_per_datasets.py
+++ b/src/autogluon_dashboard/plotting/metrics_per_datasets.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot
 import pandas
@@ -14,13 +14,13 @@ class MetricsPlotPerDataset(Plot):
         df_process: hvplot.Interactive,
         plot_type: str,
         dataset: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
-        table_cols: list = ...,
+        table_cols: list = [],
     ) -> None:
         dataset_to_plot = self._preprocess(df_process, dataset)
         super().__init__(

--- a/src/autogluon_dashboard/plotting/rank_counts_ag.py
+++ b/src/autogluon_dashboard/plotting/rank_counts_ag.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot
 import pandas
@@ -15,13 +15,13 @@ class AGRankCounts(Plot):
         plot_type: str,
         col_name: str,
         framework: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
-        table_cols: list = ...,
+        table_cols: list = [],
     ) -> None:
         dataset_to_plot = self._preprocess(df_process, framework, col_name)
         super().__init__(

--- a/src/autogluon_dashboard/plotting/top5_all_datasets.py
+++ b/src/autogluon_dashboard/plotting/top5_all_datasets.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot
 import pandas
@@ -14,13 +14,13 @@ class Top5AllDatasets(Plot):
         df_process: hvplot.Interactive,
         plot_type: str,
         col_name: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
-        table_cols: list = ...,
+        table_cols: list = [],
     ) -> None:
         dataset_to_plot = self._preprocess(df_process, col_name)
         super().__init__(

--- a/src/autogluon_dashboard/plotting/top5_per_dataset.py
+++ b/src/autogluon_dashboard/plotting/top5_per_dataset.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import hvplot
 import pandas
@@ -15,13 +15,13 @@ class Top5PerDataset(Plot):
         plot_type: str,
         col_name: str,
         dataset: str,
-        x_axis: Union[str, list] = None,
-        y_axis: Union[str, list] = None,
+        x_axis: Optional[Union[str, List[str]]] = None,
+        y_axis: Optional[Union[str, List[str]]] = None,
         graph_type: str = "bar",
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
-        table_cols: list = ...,
+        table_cols: list = [],
     ) -> None:
         dataset_to_plot = self._preprocess(df_process, dataset, col_name)
         super().__init__(

--- a/src/autogluon_dashboard/scripts/widget.py
+++ b/src/autogluon_dashboard/scripts/widget.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import panel as pn
 

--- a/tests/unittests/test_plot.py
+++ b/tests/unittests/test_plot.py
@@ -31,7 +31,7 @@ class TestPlot(unittest.TestCase):
         self.assertEqual(plot.plot_x_label, "")
         self.assertEqual(plot.plot_y_label, "")
         self.assertEqual(plot.label_rot, 90)
-        self.assertEqual(plot.table_cols, Ellipsis)
+        self.assertEqual(plot.table_cols, [])
 
     def plot_test(self, plot_obj, mock_plot):
         plot = plot_obj.plot()


### PR DESCRIPTION
This PR addresses a minor issue with type hints in the function signature for different plots. Now instead of using `Union[...] = None`, we use `Optional[Union[...]] = None` instead. Additionally, we use a more specific default argument for Optional list, as `list = []` instead of `list = ...`. 