### PR TITLE
add safety nets for dataframe loading and plot creation

### DIFF
--- a/src/autogluon_dashboard/app.py
+++ b/src/autogluon_dashboard/app.py
@@ -92,7 +92,7 @@ frameworks_list.insert(0, "All Frameworks")
 # Make DataFrame Interactive
 per_dataset_idf = per_dataset_df.interactive()
 all_framework_idf = all_framework_df.interactive()
-hware_metrics_idf = hware_metrics_df.interactive()
+hware_metrics_idf = hware_metrics_df.interactive() if hware_metrics_df is not None else None
 
 # Define Panel widgets
 frameworks_widget = SelectWidget(name=FRAMEWORK_LABEL, options=frameworks_list).create_widget()
@@ -106,15 +106,18 @@ graph_dropdown = SelectWidget(name=GRAPH_TYPE_STR, options=GRAPH_TYPES).create_w
 graph_dropdown2 = SelectWidget(name=GRAPH_TYPE_STR, options=GRAPH_TYPES).create_widget()
 nrows = SliderWidget(name=DF_WIDGET_NAME, start=0, end=len(frameworks_list) - 1, value=10).create_widget()
 nrows2 = SliderWidget(name=DF_WIDGET_NAME, start=0, end=len(frameworks_list) - 1, value=10).create_widget()
-yaxis_widget4 = SelectWidget(
-    name=HW_METRICS_WIDGET_NAME, options=list(hware_metrics_df.metric.unique())
-).create_widget()
+yaxis_widget4 = None
+if hware_metrics_df is not None:
+    yaxis_widget4 = SelectWidget(
+        name=HW_METRICS_WIDGET_NAME, options=list(hware_metrics_df.metric.unique())
+    ).create_widget()
 
 per_dataset_df.to_csv(PER_DATASET_DOWNLOAD_TITLE)
 per_dataset_csv_widget = FileDownloadWidget(file=PER_DATASET_DOWNLOAD_TITLE).create_widget()
 all_framework_df.to_csv(AGG_FRAMEWORKS_DOWNLOAD_TITLE)
 all_framework_csv_widget = FileDownloadWidget(file=AGG_FRAMEWORKS_DOWNLOAD_TITLE).create_widget()
-hware_metrics_df.to_csv(HARDWARE_METRICS_DOWNLOAD_TITLE)
+if hware_metrics_df is not None:
+    hware_metrics_df.to_csv(HARDWARE_METRICS_DOWNLOAD_TITLE)
 hware_metrics_csv_widget = FileDownloadWidget(file=HARDWARE_METRICS_DOWNLOAD_TITLE).create_widget()
 
 df_ag_only = get_df_filter_by_framework(per_dataset_df, "AutoGluon")
@@ -215,28 +218,29 @@ create_panel_object(panel_objs, FRAMEWORK_BOX_PLOT, widgets=[yaxis_widget3], plo
 pareto_front = ParetoFront(PARETO_FRONT_PLOT, all_framework_df, "pareto", x_axis=TIME_INFER_S_RESCALED, y_axis=WINRATE)
 create_panel_object(panel_objs, PARETO_FRONT_PLOT, plots=[pareto_front])
 
+hware_metrics_by_mode_plot, hware_metrics_by_dataset_plot = None, None
+if hware_metrics_idf:
+    hware_metrics_by_mode_plot = HardwareMetrics(
+        HARDWARE_METRICS_PLOT_TITLE,
+        hware_metrics_idf,
+        "hvplot",
+        col_name=yaxis_widget4,
+        x_axis="framework",
+        y_axis="statistic_value",
+        ylabel=yaxis_widget4,
+        by="mode",
+    )
 
-hware_metrics_by_mode_plot = HardwareMetrics(
-    HARDWARE_METRICS_PLOT_TITLE,
-    hware_metrics_idf,
-    "hvplot",
-    col_name=yaxis_widget4,
-    x_axis="framework",
-    y_axis="statistic_value",
-    ylabel=yaxis_widget4,
-    by="mode",
-)
-
-hware_metrics_by_dataset_plot = HardwareMetrics(
-    HARDWARE_METRICS_PLOT_TITLE,
-    hware_metrics_idf,
-    "hvplot",
-    col_name=yaxis_widget4,
-    x_axis="framework",
-    y_axis="statistic_value",
-    ylabel=yaxis_widget4,
-    by="dataset",
-)
+    hware_metrics_by_dataset_plot = HardwareMetrics(
+        HARDWARE_METRICS_PLOT_TITLE,
+        hware_metrics_idf,
+        "hvplot",
+        col_name=yaxis_widget4,
+        x_axis="framework",
+        y_axis="statistic_value",
+        ylabel=yaxis_widget4,
+        by="dataset",
+    )
 create_panel_object(
     panel_objs,
     HARDWARE_METRICS_PLOT,

--- a/src/autogluon_dashboard/utils/get_data.py
+++ b/src/autogluon_dashboard/utils/get_data.py
@@ -1,9 +1,17 @@
+import logging
+
 import pandas as pd
+
+logger = logging.getLogger("dashboard-logger")
 
 
 def get_dataframes(paths: list) -> list[pd.DataFrame]:
     dfs = []
     for dataset_path in paths:
-        df = pd.read_csv(dataset_path) if dataset_path else None
-        dfs.append(df)
+        try:
+            df = pd.read_csv(dataset_path) if dataset_path else None
+            dfs.append(df)
+        except Exception as e:
+            logger.exception(e)
+            dfs.append(None)
     return dfs

--- a/src/autogluon_dashboard/utils/panel_utils.py
+++ b/src/autogluon_dashboard/utils/panel_utils.py
@@ -1,0 +1,45 @@
+import panel as pn
+
+failure_text_widget = pn.widgets.StaticText(name="Unable to render", value="Error while trying to plot")
+
+
+def create_panel_object(panel_objs, title, widgets=[], plots=[], extra_plots=[]):
+    try:
+        for i in range(len(plots)):
+            try:
+                plots[i] = plots[i].plot()
+            except Exception as e:
+                raise e
+            try:
+                plots[i] = plots[i].opts(active_tools=[]).panel()
+            except Exception as e:
+                continue
+        panel_obj = pn.Row(title, *widgets, *plots, *extra_plots)
+        panel_objs.append(panel_obj)
+    except Exception:
+        panel_obj = pn.Row(
+            title,
+            failure_text_widget,
+        )
+        panel_objs.append(panel_obj)
+
+
+def get_error_tables_grid(error_tables, num_rows=3, num_cols=3) -> pn.Column:
+    error_table_ctr = iter(range(len(error_tables)))
+    num_cols = 3
+    num_rows = int(len(error_tables) // num_cols) + (len(error_tables) % num_cols > 0)
+    rows = []
+    for _ in range(num_rows):
+        row = []
+        try:
+            for _ in range(3):
+                try:
+                    error_framework_table = error_tables[next(error_table_ctr)]
+                    row.append(error_framework_table)
+                except Exception as e:
+                    raise e
+        except Exception:
+            break
+        rows.append(pn.Row(*row))
+    grid = pn.Column(*rows)
+    return grid

--- a/src/autogluon_dashboard/utils/panel_utils.py
+++ b/src/autogluon_dashboard/utils/panel_utils.py
@@ -32,7 +32,7 @@ def get_error_tables_grid(error_tables, num_rows=3, num_cols=3) -> pn.Column:
     for _ in range(num_rows):
         row = []
         try:
-            for _ in range(3):
+            for _ in range(num_cols):
                 try:
                     error_framework_table = error_tables[next(error_table_ctr)]
                     row.append(error_framework_table)

--- a/src/autogluon_dashboard/utils/panel_utils.py
+++ b/src/autogluon_dashboard/utils/panel_utils.py
@@ -6,13 +6,10 @@ failure_text_widget = pn.widgets.StaticText(name="Unable to render", value="Erro
 def create_panel_object(panel_objs, title, widgets=[], plots=[], extra_plots=[]):
     try:
         for i in range(len(plots)):
-            try:
-                plots[i] = plots[i].plot()
-            except Exception as e:
-                raise e
+            plots[i] = plots[i].plot()
             try:
                 plots[i] = plots[i].opts(active_tools=[]).panel()
-            except Exception as e:
+            except Exception:
                 continue
         panel_obj = pn.Row(title, *widgets, *plots, *extra_plots)
         panel_objs.append(panel_obj)
@@ -33,11 +30,8 @@ def get_error_tables_grid(error_tables, num_rows=3, num_cols=3) -> pn.Column:
         row = []
         try:
             for _ in range(num_cols):
-                try:
-                    error_framework_table = error_tables[next(error_table_ctr)]
-                    row.append(error_framework_table)
-                except Exception as e:
-                    raise e
+                error_framework_table = error_tables[next(error_table_ctr)]
+                row.append(error_framework_table)
         except Exception:
             break
         rows.append(pn.Row(*row))

--- a/tests/unittests/test_dataload.py
+++ b/tests/unittests/test_dataload.py
@@ -26,6 +26,11 @@ class TestDataLoad(unittest.TestCase):
         mock_data.assert_has_calls(calls, any_order=False)
         assert mock_data.call_count == 3
 
+    def test_data_load(self):
+        paths = "./resources/aggregated.csv", None, "./resources/aggregated.csv"
+        _, df2, _ = get_dataframes(paths)
+        self.assertEqual(df2, None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR addresses the need to prevent crashing of the website if one or more plots fail to render due to some unforeseen issue. This is solved by including several `try...except` blocks and returns a fixed failure text if the plot fails to load. 
A `try...except` block is also used when loading the datasets.
Additionally, the hardware metrics plots are made optional and are only plotted if a hardware metrics csv is passed in. 