### PR TITLE
more pareto plots, log scale for box plot, training+inference time instead of rescaled, checkbox widget

### DIFF
--- a/src/autogluon_dashboard/constants/widgets_constants.py
+++ b/src/autogluon_dashboard/constants/widgets_constants.py
@@ -1,14 +1,9 @@
-from autogluon_dashboard.constants.df_constants import (
-    BESTDIFF,
-    LOSS_RESCALED,
-    TIME_INFER_S_RESCALED,
-    TIME_TRAIN_S_RESCALED,
-)
+from autogluon_dashboard.constants.df_constants import BESTDIFF, LOSS_RESCALED, TIME_INFER_S, TIME_TRAIN_S
 
 METRICS_TO_PLOT = [
     LOSS_RESCALED,
-    TIME_TRAIN_S_RESCALED,
-    TIME_INFER_S_RESCALED,
+    TIME_TRAIN_S,
+    TIME_INFER_S,
     BESTDIFF,
 ]
 GRAPH_TYPES = ["bar", "line", "hist", "scatter"]

--- a/src/autogluon_dashboard/dashboard.py
+++ b/src/autogluon_dashboard/dashboard.py
@@ -130,6 +130,7 @@ def run_dashboard():
     os.environ["PER_DATASET_S3_PATH"] = CLOUDFRONT_DOMAIN + f"/{prefix}" + per_dataset_s3_loc
     os.environ["AGG_DATASET_S3_PATH"] = CLOUDFRONT_DOMAIN + f"/{prefix}" + aggregated_s3_loc
     os.environ["HWARE_METRICS_S3_PATH"] = CLOUDFRONT_DOMAIN + f"/{prefix}" + hware_s3_loc
+    os.environ["BOKEH_PY_LOG_LEVEL"] = "error"
 
     s3_client = boto3.client("s3")
 

--- a/src/autogluon_dashboard/plotting/framework_boxplot.py
+++ b/src/autogluon_dashboard/plotting/framework_boxplot.py
@@ -34,6 +34,8 @@ class FrameworkBoxPlot(Plot):
         label of y-axis
     label_rot: int,
         rotation value of labels on axes
+    logy: bool,
+        whether to use log scale for y-axis
 
     Methods
     -------
@@ -60,6 +62,7 @@ class FrameworkBoxPlot(Plot):
         xlabel: str = "",
         ylabel: str = "",
         label_rot: int = 90,
+        logy: bool = False,
     ) -> None:
         super(FrameworkBoxPlot, self).__init__(
             plot_title,
@@ -71,4 +74,5 @@ class FrameworkBoxPlot(Plot):
             xlabel,
             ylabel,
             label_rot,
+            logy=logy,
         )

--- a/src/autogluon_dashboard/plotting/plot.py
+++ b/src/autogluon_dashboard/plotting/plot.py
@@ -68,6 +68,7 @@ class Plot:
         table_cols: list = [],
         table_width: Optional[int] = None,
         by: str = "",
+        logy: bool = False,
     ) -> None:
         self.plot_title = plot_title
         self.df = dataset_to_plot
@@ -80,6 +81,7 @@ class Plot:
         self.label_rot = label_rot
         self.table_cols = table_cols
         self.table_width = table_width
+        self.logy = logy
 
         if plot_type == "table":
             self.plot = self._create_table
@@ -89,6 +91,20 @@ class Plot:
             self.plot = self._create_pareto_front
         elif plot_type == "box":
             self.plot = self._create_box_plot
+
+        def cleanup(self):
+            raise ValueError("YADDA")
+
+        def __del__(self):
+            # yes, a bare except clause and a pass...
+            # this is exactly what you're NOT supposed to do,
+            # never ever, because it's BAD... but here it's
+            # ok - provided you double-checked what the code
+            # in the `try` block really do, of course.
+            try:
+                self.cleanup()
+            except:
+                pass
 
     @abstractmethod
     def _preprocess(self, **kwargs):
@@ -184,7 +200,7 @@ class Plot:
         return self.df.hvplot.table(title=self.plot_title, columns=self.table_cols, width=table_width)
 
     def _create_pareto_front(
-        self, maxY: bool = True, width: Union[int, float] = 900, size: int = 400
+        self, maxY: bool = False, width: Union[int, float] = 800, size: int = 300
     ) -> hvplot.hvPlot:
         """
         Create a Pareto frontier plot leveraging the hvplot library
@@ -200,6 +216,7 @@ class Plot:
         size: int, default = 400,
             Size of points in scatter plot -> represents framework
         """
+
         Xs, Ys = self.df[self.plot_x], self.df[self.plot_y]
         sorted_list = sorted([[Xs[i], Ys[i]] for i in range(len(Xs))], reverse=False)
         pareto_front = [sorted_list[0]]
@@ -221,7 +238,7 @@ class Plot:
             c=FRAMEWORK,
             kind="scatter",
             size=size,
-            height=800,
+            height=600,
             width=width,
             grid=True,
         ) * pareto_df.hvplot.step(x="col1", y="col2")
@@ -238,4 +255,6 @@ class Plot:
         width: int, default = 1000,
             width of the plot
         """
-        return self.df.hvplot.box(self.plot_y, by=FRAMEWORK, rot=self.label_rot, height=height, width=width)
+        return self.df.hvplot.box(
+            self.plot_y, by=FRAMEWORK, rot=self.label_rot, height=height, width=width, logy=self.logy
+        )

--- a/src/autogluon_dashboard/plotting/plot.py
+++ b/src/autogluon_dashboard/plotting/plot.py
@@ -92,20 +92,6 @@ class Plot:
         elif plot_type == "box":
             self.plot = self._create_box_plot
 
-        def cleanup(self):
-            raise ValueError("YADDA")
-
-        def __del__(self):
-            # yes, a bare except clause and a pass...
-            # this is exactly what you're NOT supposed to do,
-            # never ever, because it's BAD... but here it's
-            # ok - provided you double-checked what the code
-            # in the `try` block really do, of course.
-            try:
-                self.cleanup()
-            except:
-                pass
-
     @abstractmethod
     def _preprocess(self, **kwargs):
         return

--- a/src/autogluon_dashboard/utils/panel_utils.py
+++ b/src/autogluon_dashboard/utils/panel_utils.py
@@ -1,19 +1,28 @@
+import logging
+
 import panel as pn
 
+logger = logging.getLogger("dashboard-logger")
 failure_text_widget = pn.widgets.StaticText(name="Unable to render", value="Error while trying to plot")
 
 
 def create_panel_object(panel_objs, title, widgets=[], plots=[], extra_plots=[]):
     try:
         for i in range(len(plots)):
-            plots[i] = plots[i].plot()
+            try:
+                plots[i] = plots[i].plot()
+            except AttributeError:
+                continue
+            except Exception as e:
+                raise e
             try:
                 plots[i] = plots[i].opts(active_tools=[]).panel()
             except Exception:
                 continue
         panel_obj = pn.Row(title, *widgets, *plots, *extra_plots)
         panel_objs.append(panel_obj)
-    except Exception:
+    except Exception as e:
+        logger.exception(e)
         panel_obj = pn.Row(
             title,
             failure_text_widget,

--- a/src/autogluon_dashboard/widgets/checkbox_widget.py
+++ b/src/autogluon_dashboard/widgets/checkbox_widget.py
@@ -1,0 +1,35 @@
+import panel as pn
+
+from autogluon_dashboard.widgets.widget import Widget
+
+
+class CheckboxWidget(Widget):
+    """
+    This class is used to define a Panel widget for a checkbox boolean widget.
+
+    Attributes
+    ----------
+    name: str
+        this is the name of the widget to display
+
+    Methods
+    -------
+    create_widget():
+        creates a panel `CheckBox` widget.
+
+    Usage
+    -------
+    >>> log_scale = pn.widgets.Checkbox(name='log scale for y-axis')
+
+    This will return a Panel widget that can be directly added to the dashboard and rendered by Panel
+    """
+
+    def __init__(self, name):
+        super().__init__(name=name)
+
+    def create_widget(self) -> pn.widgets.Checkbox:
+        """
+        Creates a panel `Checkbox` widget.
+        The `Checkbox` widget is diplayed as a checkbox and returns a True or False.
+        """
+        return pn.widgets.Checkbox(name=self.name)

--- a/tests/unittests/test_plot.py
+++ b/tests/unittests/test_plot.py
@@ -271,11 +271,11 @@ class TestParetoFront(unittest.TestCase):
         mock_hvplot.assert_called_once_with(
             c="framework",
             kind="scatter",
-            size=400,
+            size=300,
             x="dataset",
             y="rank",
-            height=800,
-            width=900,
+            height=600,
+            width=800,
             grid=True,
         )
 

--- a/tests/unittests/test_widget.py
+++ b/tests/unittests/test_widget.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pandas as pd
 
+from autogluon_dashboard.widgets.checkbox_widget import CheckboxWidget
 from autogluon_dashboard.widgets.filedownload_widget import FileDownloadWidget
 from autogluon_dashboard.widgets.number_widget import NumberWidget
 from autogluon_dashboard.widgets.select_widget import SelectWidget
@@ -98,6 +99,14 @@ class TestWidget(unittest.TestCase):
             embed=True,
         )
         self.assertEqual(widget, mock_create_widget.return_value)
+
+    @mock.patch("panel.widgets.Checkbox")
+    def test_create_sliderwidget(self, mock_checkbox_widget):
+        mock_checkbox_widget.return_value = "checkbox widget created"
+        test_widget = CheckboxWidget(name="test_checkbox")
+        widget = test_widget.create_widget()
+        mock_checkbox_widget.assert_called_once_with(name=test_widget.name)
+        self.assertEqual(widget, mock_checkbox_widget.return_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds several new features to the dashboard: 
1. More pareto plots comparing loss_rescaled, bestdiff, and winrate with inference time
2. The ability to toggle log scale for the framework box plot 
3. Adds a checkbox widget for usage in (2) 
4. Use training time and inference time as is instead of rescaled times 
5. Ignore bokeh warnings in command line
6. Fix sizing of pareto front plots