### PR TITLE
Adding Framework name fix

### DIFF
--- a/src/autogluon_dashboard/utils/dataset_utils.py
+++ b/src/autogluon_dashboard/utils/dataset_utils.py
@@ -98,7 +98,11 @@ def get_name_before_first_underscore(df: pandas.DataFrame, col_name: str) -> pan
     col_name: str,
         Name of Column to perform filtering on.
     """
-    return df[col_name]
+    # If not triggered with benchmark tests, then rename framework to AutoGluon
+    if not df[col_name].str.contains("master", case=False).any():
+        return df[col_name].str.extract(r"^(.*?)(?:_|$)")[0]
+    else:
+        return df[col_name]
 
 
 def clean_up_framework_names(df: pandas.DataFrame, dummy: bool = False) -> list:

--- a/src/autogluon_dashboard/utils/dataset_utils.py
+++ b/src/autogluon_dashboard/utils/dataset_utils.py
@@ -99,7 +99,7 @@ def get_name_before_first_underscore(df: pandas.DataFrame, col_name: str) -> pan
         Name of Column to perform filtering on.
     """
     # If not triggered with benchmark tests, then rename framework to AutoGluon
-    if not df[col_name].str.contains('master', case=False).any():
+    if not df[col_name].str.contains("master", case=False).any():
         return df[col_name].str.extract(r"^(.*?)(?:_|$)")[0]
     else:
         return df[col_name]

--- a/src/autogluon_dashboard/utils/dataset_utils.py
+++ b/src/autogluon_dashboard/utils/dataset_utils.py
@@ -98,11 +98,7 @@ def get_name_before_first_underscore(df: pandas.DataFrame, col_name: str) -> pan
     col_name: str,
         Name of Column to perform filtering on.
     """
-    # If not triggered with benchmark tests, then rename framework to AutoGluon
-    if not df[col_name].str.contains("master", case=False).any():
-        return df[col_name].str.extract(r"^(.*?)(?:_|$)")[0]
-    else:
-        return df[col_name]
+    return df[col_name]
 
 
 def clean_up_framework_names(df: pandas.DataFrame, dummy: bool = False) -> list:

--- a/src/autogluon_dashboard/utils/dataset_utils.py
+++ b/src/autogluon_dashboard/utils/dataset_utils.py
@@ -96,9 +96,26 @@ def get_name_before_first_underscore(df: pandas.DataFrame, col_name: str) -> pan
     ----------
     df: Pandas dataframe,
     col_name: str,
-        Name of Column to perform regex on.
+        Name of Column to perform filtering on.
     """
-    return df[col_name].str.extract(r"^(.*?)(?:_|$)")[0]
+    frame_dict = {}
+    for index, row in df.iterrows():
+        if (row[col_name].split('_')[-1] not in frame_dict) and ("AutoGluon" in row[col_name]): 
+            frame_dict[row[col_name].split('_')[-1]] = index
+
+    # If there are multiple framework names starting with AutoGluon then rename them in order of timestamp
+    # To handle benchmark integration case where comparison is between different versions of AutoGluon
+    if len(frame_dict) > 1:
+        sorted_items = sorted(frame_dict.items()) 
+        earliest_timestamp = sorted_items[0][0]
+
+        value_mapping = {earliest_timestamp: 'master'}
+        for i, (key, value) in enumerate(sorted_items[1:], start=1):
+            value_mapping[key] = f'PR_{i}'
+
+        df[col_name] = df[col_name].apply(lambda x: value_mapping.get(x.split('_')[-1], x))
+
+    return df[col_name]
 
 
 def clean_up_framework_names(df: pandas.DataFrame, dummy: bool = False) -> list:

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -61,7 +61,7 @@ class TestUtils(unittest.TestCase):
     def test_get_name_before_first_underscore(self):
         data = {"names": ["name_2_wfwe@_@323__2", "a__sas234", "1234_12", "_23edsdd"]}
         mock_df = pd.DataFrame(data)
-        excepted_names = pd.Series(["name", "a", "1234", ""])
+        excepted_names = pd.Series(["name_2_wfwe@_@323__2", "a__sas234", "1234_12", "_23edsdd"])
         new_names = get_name_before_first_underscore(mock_df, "names")
         assert new_names.equals(excepted_names)
 

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -61,7 +61,7 @@ class TestUtils(unittest.TestCase):
     def test_get_name_before_first_underscore(self):
         data = {"names": ["name_2_wfwe@_@323__2", "a__sas234", "1234_12", "_23edsdd"]}
         mock_df = pd.DataFrame(data)
-        excepted_names = pd.Series(["name_2_wfwe@_@323__2", "a__sas234", "1234_12", "_23edsdd"])
+        excepted_names = pd.Series(["name", "a", "1234", ""])
         new_names = get_name_before_first_underscore(mock_df, "names")
         assert new_names.equals(excepted_names)
 


### PR DESCRIPTION
**Description**
A small change which is only applicable when there are multiple versions of AutoGluon frameworks in the cleaned and aggregated files.
If the dashboard is triggered by Benchmark tests then it will not perform filtering.
If the dashboard is run manually then filtering + formatting of framework names is not performed.
Eg: _AutoGluon_good_1h_ag_bench_20230913T214333_ will be reformatted to _AutoGluon_ as before.
_AutoGluon_master_, _AutoGluon_PR_1_ will not be reformatted as these are from the benchmark tests.